### PR TITLE
Fix graph rendering

### DIFF
--- a/src/compiler/genDot.ml
+++ b/src/compiler/genDot.ml
@@ -190,24 +190,19 @@ let graph_filter p g ~(filter : filtering) (starts_v : Variable.Set.t) =
   in
   let rec aux v incl =
     let es = Variable.Graph.succ_e g v in
-    match es with [] -> Some incl | _ ->
-      List.fold_left (fun inclo (_s, k, e) ->
-          if Variable.Set.mem e incl then inclo else
-          if Variable.BDT.contradictory_knowledge filter.event_knowledge k
-          then inclo else
-          if match_context e then
-            match inclo, aux e (Variable.Set.add e incl) with
-            | inclo, None -> inclo
-            | None, Some i -> Some i
-            | Some io, Some i -> Some (Variable.Set.union i io)
-          else inclo)
-        None es
+    let incl = Variable.Set.add v incl in
+    match es with [] -> incl | _ ->
+      List.fold_left (fun incl (_,k,e) ->
+          if Variable.Set.mem e incl 
+          || Variable.BDT.contradictory_knowledge filter.event_knowledge k
+          || not (match_context e)
+          then incl
+          else aux e incl
+        ) incl es
   in
   let starts = Variable.Set.filter (Variable.Graph.mem_vertex g) starts_v in
   Variable.Set.fold (fun v incl ->
-      match aux v incl with
-      | None -> incl
-      | Some i -> Variable.Set.union i incl)
+      Variable.Set.union (aux v incl) incl)
     starts starts
 
 let graph_of_program p filter =


### PR DESCRIPTION
This PR fixes some erroneous rendering of the graph. Concretely:
- It removes "default" edges (and do not displays events without related downstream nodes).
- It iterates on and adds, all nodes, comparing to the past version when some nodes in some circumstances could be lacked. 